### PR TITLE
add morphdom permanent

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,7 +9,11 @@ document.addEventListener("turbo:before-render", (event) => {
   prevPath = window.location.pathname;
   event.detail.render = async (prevEl, newEl) => {
     await new Promise((resolve) => setTimeout(() => resolve(), 0));
-    morphdom(prevEl, newEl);
+    morphdom(prevEl, newEl, {
+      onBeforeElUpdated: (fromEl, toEl) => {
+        return !(fromEl.dataset.morphdomTurboPermanent && fromEl.id === toEl.id);
+      },
+    });
   };
 
   if (document.startViewTransition) {

--- a/app/views/albums/_aside.html.erb
+++ b/app/views/albums/_aside.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (album: nil) -%>
-<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"turbo-permanent" => true}, "transition-name" => "aside" do %>
+<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"morphdom-turbo-permanent" => true}, "transition-name" => "aside" do %>
   <% next unless album %>
   <div transition-id="<%= album.id %>">
     <div class="album-info">

--- a/app/views/shared/_player.html.erb
+++ b/app/views/shared/_player.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (track:, station: nil) -%>
-<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-turbo-permanent>
+<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-morphdom-turbo-permanent>
   <% if track %>
     <div class="player--timeline">
       <div class="player--timeline-progress" style="width:11%;"></div>


### PR DESCRIPTION
Если не отключать кэш, все равно наблюдается некорректное поведение в некоторых случаях, пробовал оверрайдить `PageRenderer`, но как-то не удалось прийти к рабочему решению. 

Чтобы воспроизвести достаточно изначально зайти на главную, потом перейти в альбом и запустить трек, а потом вернуться обратно. При первом переходе `prevEl` содержит плеер, а `newEl` по сути достается из кэша в той версии, где плеера еще нет. И получается, что плеер добавляется заново и анимация сбрасывается

И как-то я не до конца понимаю, почему если на другом элементе присутствует `data-turbo-permanent`, то морф-пермамент не отрабатывает на плеере. По сути ведь когда турбо берет свои перманентные элементы, он только их в DOM-е и заменяет (https://github.com/hotwired/turbo/blob/main/src/core/bardo.ts#L52), т.е тот элемент на котором был указан `morphdom-turbo-permanent` должен был попасть в морфдом и обновиться